### PR TITLE
ran convert to latest swift syntax on Xcode 8.3.2 and swift 3.1

### DIFF
--- a/Stackable.podspec
+++ b/Stackable.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stackable'
-  s.version      = '0.1.14'
+  s.version      = '0.2.0'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = 'iOS framework for laying out nested views vertically and horizontally'
   

--- a/stackable.xcodeproj/project.pbxproj
+++ b/stackable.xcodeproj/project.pbxproj
@@ -199,9 +199,11 @@
 				TargetAttributes = {
 					9D38FED71D73A077001CB50F = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 					9D38FEE11D73A078001CB50F = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -391,6 +393,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -409,6 +412,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.seek.stackable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -419,6 +423,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.seek.stackableTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -429,6 +434,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.seek.stackableTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/stackable/FixedSizeStackable.swift
+++ b/stackable/FixedSizeStackable.swift
@@ -3,7 +3,7 @@
 
 import UIKit
 
-public class FixedSizeStackable: StackableItem {
+open class FixedSizeStackable: StackableItem {
     var view: UIView
     var size: CGSize
     
@@ -12,11 +12,11 @@ public class FixedSizeStackable: StackableItem {
         self.size = size
     }
     
-    public func heightForWidth(width: CGFloat) -> CGFloat {
+    open func heightForWidth(_ width: CGFloat) -> CGFloat {
         return self.size.height
     }
     
-    public var hidden: Bool {
-        return view.hidden
+    open var hidden: Bool {
+        return view.isHidden
     }
 }

--- a/stackable/FrameArray+bottom.swift
+++ b/stackable/FrameArray+bottom.swift
@@ -8,7 +8,7 @@ extension Array where Element: CGRectProtocol {
     var bottom: CGFloat {
         var bottom: CGFloat = 0.0
         for frame in self {
-            bottom = max(bottom, frame.bottom)
+            bottom = Swift.max(bottom, frame.bottom)
         }
         return bottom
     }

--- a/stackable/HStack.swift
+++ b/stackable/HStack.swift
@@ -3,18 +3,18 @@
 
 import UIKit
 
-public class HStack: Stack {
-    public let thingsToStack: [Stackable]
-    public let spacing: CGFloat
-    public let layoutMargins: UIEdgeInsets
+open class HStack: Stack {
+    open let thingsToStack: [Stackable]
+    open let spacing: CGFloat
+    open let layoutMargins: UIEdgeInsets
     
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsetsZero, thingsToStack: [Stackable]) {
+    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable]) {
         self.spacing = spacing
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
     }
     
-    public func framesForLayout(width: CGFloat, origin: CGPoint) -> [CGRect] {
+    open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         // TODO: add adjustments for layoutMargins (not currently needed so okay to defer)
         
         let thingsToStack = self.visibleThingsToStack()
@@ -38,11 +38,11 @@ public class HStack: Stack {
             
             if let stack = stackable as? Stack {
                 let innerFrames = stack.framesForLayout(stackableWidth, origin: CGPoint(x: x, y: origin.y))
-                frames.appendContentsOf(innerFrames)
+                frames.append(contentsOf: innerFrames)
                 x += stackableWidth
             } else if let item = stackable as? StackableItem {
                 let stackableHeight = item.heightForWidth(stackableWidth)
-                let frame = CGRectMake(x, y, stackableWidth, stackableHeight)
+                let frame = CGRect(x: x, y: y, width: stackableWidth, height: stackableHeight)
                 frames.append(frame)
                 x += stackableWidth
             }
@@ -53,9 +53,9 @@ public class HStack: Stack {
     
     // MARK: helpers
     
-    private func widthForNonFixedSizeStackables(width: CGFloat, thingsToStack: [Stackable]) -> CGFloat {
-        let fixedWidths = thingsToStack.filter({ $0 is FixedSizeStackable }).map({ ($0 as? FixedSizeStackable ?? FixedSizeStackable(view: UIView(), size: CGSizeZero)).size.width })
-        let totalFixedWidth = fixedWidths.reduce(0.0, combine:+)
+    fileprivate func widthForNonFixedSizeStackables(_ width: CGFloat, thingsToStack: [Stackable]) -> CGFloat {
+        let fixedWidths = thingsToStack.filter({ $0 is FixedSizeStackable }).map({ ($0 as? FixedSizeStackable ?? FixedSizeStackable(view: UIView(), size: CGSize.zero)).size.width })
+        let totalFixedWidth = fixedWidths.reduce(0.0, +)
         let totalNonFixedWidth = width - totalFixedWidth - (((CGFloat(thingsToStack.count) - 1) * self.spacing))
         let numberOfStackablesWithNonFixedWidth = thingsToStack.count - fixedWidths.count
         return  floor(totalNonFixedWidth / CGFloat(numberOfStackablesWithNonFixedWidth))

--- a/stackable/Stack.swift
+++ b/stackable/Stack.swift
@@ -7,7 +7,7 @@ public protocol Stack: class, Stackable {
     var thingsToStack: [Stackable] { get }
     var spacing: CGFloat { get }
     var layoutMargins: UIEdgeInsets { get }
-    func framesForLayout(width: CGFloat, origin: CGPoint) -> [CGRect]
+    func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect]
 }
 
 extension Stack {
@@ -19,14 +19,14 @@ extension Stack {
         return self.thingsToStack.filter({ !$0.hidden })
     }
 
-    private func viewsToLayout() -> [UIView] {
+    fileprivate func viewsToLayout() -> [UIView] {
         var views: [UIView] = []
         let thingsToStack = self.visibleThingsToStack()
         for i in 0..<thingsToStack.count {
             let stackable = thingsToStack[i]
             if let stack = stackable as? Stack {
                 let innerViews = stack.viewsToLayout()
-                views.appendContentsOf(innerViews)
+                views.append(contentsOf: innerViews)
             } else {
                 if let view = stackable as? UIView {
                     views.append(view)
@@ -38,7 +38,7 @@ extension Stack {
         return views
     }
     
-    public func layoutWithFrames(frames: [CGRect]) {
+    public func layoutWithFrames(_ frames: [CGRect]) {
         let views = self.viewsToLayout()
 
         assert(frames.count == views.count, "layoutWithFrames could not be performed because of frame(\(frames.count)) / view(\(views.count)) count mismatch")
@@ -50,11 +50,11 @@ extension Stack {
         }
     }
 
-    public func heightForFrames(frames: [CGRect]) -> CGFloat {
+    public func heightForFrames(_ frames: [CGRect]) -> CGFloat {
         return frames.bottom + self.layoutMargins.bottom
     }
 
-    public func framesForLayout(width: CGFloat) -> [CGRect] {
-        return self.framesForLayout(width, origin: CGPointZero)
+    public func framesForLayout(_ width: CGFloat) -> [CGRect] {
+        return self.framesForLayout(width, origin: CGPoint.zero)
     }
 }

--- a/stackable/StackableItem.swift
+++ b/stackable/StackableItem.swift
@@ -4,5 +4,5 @@
 import UIKit
 
 public protocol StackableItem: Stackable {
-    func heightForWidth(width: CGFloat) -> CGFloat    
+    func heightForWidth(_ width: CGFloat) -> CGFloat    
 }

--- a/stackable/UILabel+stackable.swift
+++ b/stackable/UILabel+stackable.swift
@@ -4,7 +4,7 @@
 import UIKit
 
 extension UILabel: StackableItem {
-    public func heightForWidth(width: CGFloat) -> CGFloat {
-        return self.sizeThatFits(CGSizeMake(width, 9999)).height
+    public func heightForWidth(_ width: CGFloat) -> CGFloat {
+        return self.sizeThatFits(CGSize(width: width, height: 9999)).height
     }
 }

--- a/stackable/UIView+stackSize.swift
+++ b/stackable/UIView+stackSize.swift
@@ -4,7 +4,7 @@
 import UIKit
 
 extension UIView {
-    public func stackSize(size: CGSize) -> FixedSizeStackable {
+    public func stackSize(_ size: CGSize) -> FixedSizeStackable {
         return FixedSizeStackable(view: self, size: size)
     }
 }

--- a/stackable/VStack.swift
+++ b/stackable/VStack.swift
@@ -3,21 +3,21 @@
 
 import UIKit
 
-public class VStack: Stack  {
-    public let thingsToStack: [Stackable]
-    public let spacing: CGFloat
-    public let layoutMargins: UIEdgeInsets
+open class VStack: Stack  {
+    open let thingsToStack: [Stackable]
+    open let spacing: CGFloat
+    open let layoutMargins: UIEdgeInsets
     
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsetsZero, thingsToStack: [Stackable]) {
+    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable]) {
         self.spacing = spacing
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
     }
     
-    public func framesForLayout(width: CGFloat, origin: CGPoint) -> [CGRect] {
+    open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         var origin = origin
         var width = width
-        if layoutMargins != UIEdgeInsetsZero {
+        if layoutMargins != UIEdgeInsets.zero {
             origin.x = layoutMargins.left
             origin.y = layoutMargins.top
             width -= (layoutMargins.left + layoutMargins.right)
@@ -32,11 +32,11 @@ public class VStack: Stack  {
             let stackable = thingsToStack[i]
             if let stack = stackable as? Stack {
                 let innerFrames = stack.framesForLayout(width, origin: CGPoint(x: origin.x, y: y))
-                frames.appendContentsOf(innerFrames)
+                frames.append(contentsOf: innerFrames)
                 y = frames.bottom
             } else if let item = stackable as? StackableItem {
                 let height = item.heightForWidth(width)
-                let frame = CGRectMake(origin.x, y, width, height)
+                let frame = CGRect(x: origin.x, y: y, width: width, height: height)
                 frames.append(frame)
                 y += height
             }

--- a/stackableTests/CGRectProtocol+bottom+Tests.swift
+++ b/stackableTests/CGRectProtocol+bottom+Tests.swift
@@ -12,7 +12,7 @@ class CGRectProtocol_bottom_Tests: XCTestCase {
         let width: CGFloat = 100
         let height: CGFloat = 50
         
-        let rect = CGRectMake(x, y, width, height)
+        let rect = CGRect(x: x, y: y, width: width, height: height)
         
         XCTAssertEqual(rect.bottom, y + height)
     }

--- a/stackableTests/FixedSizeStackableTests.swift
+++ b/stackableTests/FixedSizeStackableTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class FixedSizeStackableTests: XCTestCase {
     func test_view_should_return_expected() {
         let view = UIView()
-        let stackable = FixedSizeStackable(view: view, size: CGSizeMake(100, 50))
+        let stackable = FixedSizeStackable(view: view, size: CGSize(width: 100, height: 50))
         
         XCTAssertTrue(stackable.view === view)
     }
@@ -16,7 +16,7 @@ class FixedSizeStackableTests: XCTestCase {
     func test_size_should_return_expected() {
         let width: CGFloat = 100
         let height: CGFloat = 50
-        let stackable = FixedSizeStackable(view: UIView(), size: CGSizeMake(width, height))
+        let stackable = FixedSizeStackable(view: UIView(), size: CGSize(width: width, height: height))
         
         XCTAssertEqual(stackable.size.width, width)
         XCTAssertEqual(stackable.size.height, height)
@@ -25,7 +25,7 @@ class FixedSizeStackableTests: XCTestCase {
     func test_heightForWidth_should_return_expected() {
         let width: CGFloat = 100
         let height: CGFloat = 50
-        let stackable = FixedSizeStackable(view: UIView(), size: CGSizeMake(width, height))
+        let stackable = FixedSizeStackable(view: UIView(), size: CGSize(width: width, height: height))
         
         let result = stackable.heightForWidth(width)
         
@@ -34,11 +34,11 @@ class FixedSizeStackableTests: XCTestCase {
     
     func test_hidden_should_return_expected() {
         let view = UIView()
-        let stackable = FixedSizeStackable(view: view, size: CGSizeMake(100, 50))
+        let stackable = FixedSizeStackable(view: view, size: CGSize(width: 100, height: 50))
         
-        view.hidden = false
+        view.isHidden = false
         XCTAssertFalse(stackable.hidden)
-        view.hidden = true
+        view.isHidden = true
         XCTAssertTrue(stackable.hidden)
     }
 }

--- a/stackableTests/FrameArray+bottom+Tests.swift
+++ b/stackableTests/FrameArray+bottom+Tests.swift
@@ -8,9 +8,9 @@ import XCTest
 class FrameArray_bottom_Tests: XCTestCase {
     func test_bottom_should_return_bottom_of_lowest_frame() {
         let frames = [
-            CGRectMake(0, 10, 0, 50),
-            CGRectMake(0, 10, 0, 80),
-            CGRectMake(0, 10, 0, 20)
+            CGRect(x: 0, y: 10, width: 0, height: 50),
+            CGRect(x: 0, y: 10, width: 0, height: 80),
+            CGRect(x: 0, y: 10, width: 0, height: 20)
         ]
         
         XCTAssertEqual(frames.bottom, frames[1].origin.y + frames[1].height)

--- a/stackableTests/HStackTests.swift
+++ b/stackableTests/HStackTests.swift
@@ -9,11 +9,11 @@ class HStackTests: XCTestCase {
     func test_framesForLayout_should_return_spaced_frames() {
         let spacing: CGFloat = 2
         let view1 = UIView()
-        let size1 = CGSizeMake(50, 10)
+        let size1 = CGSize(width: 50, height: 10)
         let view2 = UIView()
-        let size2 = CGSizeMake(55, 11)
+        let size2 = CGSize(width: 55, height: 11)
         let view3 = UIView()
-        let size3 = CGSizeMake(60, 12)
+        let size3 = CGSize(width: 60, height: 12)
         
         let stack = HStack(spacing: spacing, thingsToStack: [
             view1.stackSize(size1),
@@ -48,9 +48,9 @@ class HStackTests: XCTestCase {
 
         let spacing: CGFloat = 2
         let view1 = UIView()
-        let size1 = CGSizeMake(50, 10)
+        let size1 = CGSize(width: 50, height: 10)
         let view2 = UIView()
-        let size2 = CGSizeMake(55, 11)
+        let size2 = CGSize(width: 55, height: 11)
         
         let stack = HStack(spacing: spacing, layoutMargins: UIEdgeInsetsMake(topMargin, leftMargin, bottomMargin, rightMargin), thingsToStack: [
             view1.stackSize(size1),
@@ -75,11 +75,11 @@ class HStackTests: XCTestCase {
         let spacing: CGFloat = 2
         let spacing2: CGFloat = 1
         let view1 = UIView()
-        let size1 = CGSizeMake(50, 10)
+        let size1 = CGSize(width: 50, height: 10)
         let view2 = UIView()
-        let size2 = CGSizeMake(55, 11)
+        let size2 = CGSize(width: 55, height: 11)
         let view3 = UIView()
-        let size3 = CGSizeMake(60, 12)
+        let size3 = CGSize(width: 60, height: 12)
         
         let stack = HStack(spacing: spacing, thingsToStack: [
             VStack(spacing: spacing2, thingsToStack: [

--- a/stackableTests/StackTests.swift
+++ b/stackableTests/StackTests.swift
@@ -8,9 +8,9 @@ import XCTest
 class StackTests: XCTestCase {
     func test_hidden_for_all_hidden_should_return_true() {
         let label1 = UILabel()
-        label1.hidden = true
+        label1.isHidden = true
         let label2 = UILabel()
-        label2.hidden = true
+        label2.isHidden = true
         let stack = MockStack(thingsToStack: [ label1, label2 ])
         
         XCTAssertTrue(stack.hidden)
@@ -18,9 +18,9 @@ class StackTests: XCTestCase {
     
     func test_hidden_for_not_all_hidden_should_return_false() {
         let label1 = UILabel()
-        label1.hidden = true
+        label1.isHidden = true
         let label2 = UILabel()
-        label2.hidden = false
+        label2.isHidden = false
         let stack = MockStack(thingsToStack: [ label1, label2 ])
         
         XCTAssertFalse(stack.hidden)
@@ -28,11 +28,11 @@ class StackTests: XCTestCase {
     
     func test_visibleThingsToStack_should_return_only_non_hidden_stackables() {
         let label1 = UILabel()
-        label1.hidden = true
+        label1.isHidden = true
         let label2 = UILabel()
-        label2.hidden = false
+        label2.isHidden = false
         let label3 = UILabel()
-        label3.hidden = false
+        label3.isHidden = false
         let stack = MockStack(thingsToStack: [ label1, label2, label3 ])
         
         let visibleStackables = stack.visibleThingsToStack()
@@ -45,9 +45,9 @@ class StackTests: XCTestCase {
         let label1 = UILabel()
         let label2 = UILabel()
         let label3 = UILabel()
-        let frame1 = CGRectMake(0, 0, 20, 10)
-        let frame2 = CGRectMake(0, 10, 20, 10)
-        let frame3 = CGRectMake(0, 20, 20, 10)
+        let frame1 = CGRect(x: 0, y: 0, width: 20, height: 10)
+        let frame2 = CGRect(x: 0, y: 10, width: 20, height: 10)
+        let frame3 = CGRect(x: 0, y: 20, width: 20, height: 10)
         let stack = MockStack(thingsToStack: [ label1, MockStack(thingsToStack: [ label2 ]), label3 ])
         
         stack.layoutWithFrames([ frame1, frame2, frame3 ])
@@ -61,9 +61,9 @@ class StackTests: XCTestCase {
         let label1 = UILabel()
         let label2 = UILabel()
         let label3 = UILabel()
-        let frame1 = CGRectMake(0, 0, 20, 10)
-        let frame2 = CGRectMake(0, 10, 20, 10)
-        let frame3 = CGRectMake(0, 20, 20, 10)
+        let frame1 = CGRect(x: 0, y: 0, width: 20, height: 10)
+        let frame2 = CGRect(x: 0, y: 10, width: 20, height: 10)
+        let frame3 = CGRect(x: 0, y: 20, width: 20, height: 10)
         let topMargin: CGFloat = 10
         let leftMargin: CGFloat = 8
         let rightMargin: CGFloat = 8
@@ -81,17 +81,17 @@ class StackTests: XCTestCase {
         let spacing: CGFloat
         let layoutMargins: UIEdgeInsets
         
-        init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsetsZero, thingsToStack: [Stackable]) {
+        init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable]) {
             self.spacing = spacing
             self.layoutMargins = layoutMargins
             self.thingsToStack = thingsToStack
         }        
  
-        func framesForLayout(width: CGFloat, origin: CGPoint) -> [CGRect] {
+        func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
             fatalError("not implemented")
         }
 
-        func framesForLayout(width: CGFloat) -> [CGRect] {
+        func framesForLayout(_ width: CGFloat) -> [CGRect] {
             fatalError("not implemented")
         }
     }

--- a/stackableTests/UILabel+heightForWidth+Tests.swift
+++ b/stackableTests/UILabel+heightForWidth+Tests.swift
@@ -7,14 +7,14 @@ import XCTest
 
 class UILabel_heightForWidth_Tests: XCTestCase {
     func test_heightForWidth_should_return_expected_result() {
-        let font = UIFont.systemFontOfSize(12, weight: UIFontWeightMedium)
+        let font = UIFont.systemFont(ofSize: 12, weight: UIFontWeightMedium)
         let text = "some text"
         let width: CGFloat = 100
         let label = UILabel()
         label.text = text
         label.font = font
         
-        let expectedHeight = label.sizeThatFits(CGSizeMake(width, 9999)).height
+        let expectedHeight = label.sizeThatFits(CGSize(width: width, height: 9999)).height
         let result = label.heightForWidth(width)
         
         XCTAssertEqual(result, expectedHeight)

--- a/stackableTests/UIView+stackSize+Tests.swift
+++ b/stackableTests/UIView+stackSize+Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class UIView_stackSize_Tests: XCTestCase {
     func test_stackSize_should_return_expected_result() {
-        let size = CGSizeMake(100, 50)
+        let size = CGSize(width: 100, height: 50)
         
         let view = UIView()
         let result = view.stackSize(size)

--- a/stackableTests/VStackTests.swift
+++ b/stackableTests/VStackTests.swift
@@ -16,9 +16,9 @@ class VStackTests: XCTestCase {
         let height3: CGFloat = 12
         
         let stack = VStack(spacing: spacing, thingsToStack: [
-            view1.stackSize(CGSizeMake(100, height1)),
-            view2.stackSize(CGSizeMake(100, height2)),
-            view3.stackSize(CGSizeMake(100, height3))
+            view1.stackSize(CGSize(width: 100, height: height1)),
+            view2.stackSize(CGSize(width: 100, height: height2)),
+            view3.stackSize(CGSize(width: 100, height: height3))
             ])
         
         let frames = stack.framesForLayout(200)
@@ -53,8 +53,8 @@ class VStackTests: XCTestCase {
         let height2: CGFloat = 11
         
         let stack = VStack(spacing: spacing, layoutMargins: UIEdgeInsetsMake(topMargin, leftMargin, bottomMargin, rightMargin), thingsToStack: [
-            view1.stackSize(CGSizeMake(100, height1)),
-            view2.stackSize(CGSizeMake(100, height2))
+            view1.stackSize(CGSize(width: 100, height: height1)),
+            view2.stackSize(CGSize(width: 100, height: height2))
             ])
         
         let frames = stack.framesForLayout(200)
@@ -82,10 +82,10 @@ class VStackTests: XCTestCase {
         let height3: CGFloat = 12
         
         let stack = VStack(spacing: spacing, thingsToStack: [
-            view1.stackSize(CGSizeMake(100, height1)),
+            view1.stackSize(CGSize(width: 100, height: height1)),
             VStack(spacing: spacing2, thingsToStack: [
-                view2.stackSize(CGSizeMake(100, height2)),
-                view3.stackSize(CGSizeMake(100, height3))
+                view2.stackSize(CGSize(width: 100, height: height2)),
+                view3.stackSize(CGSize(width: 100, height: height3))
                 ])
             ])
         
@@ -114,12 +114,12 @@ class VStackTests: XCTestCase {
         let height1: CGFloat = 10
         let spacing2: CGFloat = 10
         let view2 = UIView()
-        let size2 = CGSizeMake(50, 11)
+        let size2 = CGSize(width: 50, height: 11)
         let view3 = UIView()
-        let size3 = CGSizeMake(60, 12)
+        let size3 = CGSize(width: 60, height: 12)
         
         let stack = VStack(spacing: spacing, thingsToStack: [
-            view1.stackSize(CGSizeMake(100, height1)),
+            view1.stackSize(CGSize(width: 100, height: height1)),
             HStack(spacing: spacing2, thingsToStack: [
                 view2.stackSize(size2),
                 view3.stackSize(size3)


### PR DESCRIPTION
This is required in order for SEEK-IOS APP to use this pod  on Xcode 8.3.2 and swift 3.1.

The error message received was: 
`Module compiled with Swift 3.0.2 cannot be imported in Swift 3.1`