### PR TITLE
Upgraded to Swift 3.1. No code changes required

### DIFF
--- a/Stackable.podspec
+++ b/Stackable.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stackable'
-  s.version      = '0.3.0'
+  s.version      = '0.3.1'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = 'iOS framework for laying out nested views vertically and horizontally'
   

--- a/stackable.xcodeproj/project.pbxproj
+++ b/stackable.xcodeproj/project.pbxproj
@@ -199,11 +199,11 @@
 				TargetAttributes = {
 					9D38FED71D73A077001CB50F = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 0830;
 					};
 					9D38FEE11D73A078001CB50F = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};


### PR DESCRIPTION
Almost no change when upgrading to Swift 3.1.
I think this is still required in order to avoid:
`Module compiled with Swift 3.0.2 cannot be imported in Swift 3.1` error when running seek ios app on Xcode 8.3.2