### PR TITLE
Introduces width on `Stack`

### DIFF
--- a/stackable/HStack.swift
+++ b/stackable/HStack.swift
@@ -7,11 +7,13 @@ open class HStack: Stack {
     open let thingsToStack: [Stackable]
     open let spacing: CGFloat
     open let layoutMargins: UIEdgeInsets
+    open let width: CGFloat?
     
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable]) {
+    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
         self.spacing = spacing
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
+        self.width = width
     }
     
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
@@ -27,11 +29,13 @@ open class HStack: Stack {
             if i > 0 {
                 x += self.spacing
             }
-
+            
             let stackable = thingsToStack[i]
             let stackableWidth: CGFloat!
             if let fixedSizeStackable = stackable as? FixedSizeStackable {
                 stackableWidth = fixedSizeStackable.size.width
+            } else if let fixedSizeStack = stackable as? Stack, let stackWidth = fixedSizeStack.width {
+                stackableWidth = stackWidth
             } else {
                 stackableWidth = nonFixedWidth
             }
@@ -52,9 +56,19 @@ open class HStack: Stack {
     }
     
     // MARK: helpers
-    
     fileprivate func widthForNonFixedSizeStackables(_ width: CGFloat, thingsToStack: [Stackable]) -> CGFloat {
-        let fixedWidths = thingsToStack.filter({ $0 is FixedSizeStackable }).map({ ($0 as? FixedSizeStackable ?? FixedSizeStackable(view: UIView(), size: CGSize.zero)).size.width })
+        let fixedWidths = thingsToStack.filter({
+            $0 is FixedSizeStackable || ($0 as? Stack)?.width != nil
+        }).map { (stackable) -> CGFloat in
+            if let stack = stackable as? Stack, let stackWidth = stack.width {
+                return stackWidth
+            } else if let fixedSizeStackable = stackable as? FixedSizeStackable {
+                return fixedSizeStackable.size.width
+            } else {
+                return 0
+            }
+        }
+        
         let totalFixedWidth = fixedWidths.reduce(0.0, +)
         let totalNonFixedWidth = width - totalFixedWidth - (((CGFloat(thingsToStack.count) - 1) * self.spacing))
         let numberOfStackablesWithNonFixedWidth = thingsToStack.count - fixedWidths.count

--- a/stackable/Stack.swift
+++ b/stackable/Stack.swift
@@ -7,6 +7,7 @@ public protocol Stack: class, Stackable {
     var thingsToStack: [Stackable] { get }
     var spacing: CGFloat { get }
     var layoutMargins: UIEdgeInsets { get }
+    var width: CGFloat? { get }
     func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect]
 }
 
@@ -18,7 +19,7 @@ extension Stack {
     func visibleThingsToStack() -> [Stackable] {
         return self.thingsToStack.filter({ !$0.hidden })
     }
-
+    
     fileprivate func viewsToLayout() -> [UIView] {
         var views: [UIView] = []
         let thingsToStack = self.visibleThingsToStack()
@@ -40,7 +41,7 @@ extension Stack {
     
     public func layoutWithFrames(_ frames: [CGRect]) {
         let views = self.viewsToLayout()
-
+        
         assert(frames.count == views.count, "layoutWithFrames could not be performed because of frame(\(frames.count)) / view(\(views.count)) count mismatch")
         
         if views.count == frames.count {
@@ -49,11 +50,11 @@ extension Stack {
             }
         }
     }
-
+    
     public func heightForFrames(_ frames: [CGRect]) -> CGFloat {
         return frames.bottom + self.layoutMargins.bottom
     }
-
+    
     public func framesForLayout(_ width: CGFloat) -> [CGRect] {
         return self.framesForLayout(width, origin: CGPoint.zero)
     }

--- a/stackable/VStack.swift
+++ b/stackable/VStack.swift
@@ -7,19 +7,21 @@ open class VStack: Stack  {
     open let thingsToStack: [Stackable]
     open let spacing: CGFloat
     open let layoutMargins: UIEdgeInsets
+    open let width: CGFloat?
     
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable]) {
+    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
         self.spacing = spacing
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
+        self.width = width
     }
     
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         var origin = origin
         var width = width
         if layoutMargins != UIEdgeInsets.zero {
-            origin.x = layoutMargins.left
-            origin.y = layoutMargins.top
+            origin.x += layoutMargins.left
+            origin.y += layoutMargins.top
             width -= (layoutMargins.left + layoutMargins.right)
         }
         let thingsToStack = self.visibleThingsToStack()

--- a/stackableTests/HStackTests.swift
+++ b/stackableTests/HStackTests.swift
@@ -107,4 +107,42 @@ class HStackTests: XCTestCase {
         XCTAssertEqual(frames[2].size.width, size3.width)
         XCTAssertEqual(frames[2].size.height, size3.height)
     }
+    
+    func test_framesForLayout_should_return_frames_for_nested_vstack_with_fixed_width() {
+        let spacing: CGFloat = 2
+        let spacing2: CGFloat = 1
+        let view1 = UIView()
+        let size1 = CGSize(width: 100, height: 10)
+        let view2 = UIView()
+        let size2 = CGSize(width: 100, height: 11)
+        let view3 = UIView()
+        let size3 = CGSize(width: 60, height: 12)
+        let fixedVStackWidth: CGFloat = 50
+        
+        let stack = HStack(spacing: spacing, thingsToStack: [
+            VStack(spacing: spacing2, thingsToStack: [
+                view1.stackSize(size1),
+                view2.stackSize(size2)
+            ], width: fixedVStackWidth),
+            view3.stackSize(size3)
+        ])
+        
+        let frames = stack.framesForLayout(200)
+        XCTAssertEqual(frames.count, 3)
+        // view1
+        XCTAssertEqual(frames[0].origin.x, 0)
+        XCTAssertEqual(frames[0].origin.y, 0)
+        XCTAssertEqual(frames[0].size.width, fixedVStackWidth)
+        XCTAssertEqual(frames[0].size.height, size1.height)
+        // view2
+        XCTAssertEqual(frames[1].origin.x, 0)
+        XCTAssertEqual(frames[1].origin.y, size1.height + spacing2)
+        XCTAssertEqual(frames[1].size.width, fixedVStackWidth)
+        XCTAssertEqual(frames[1].size.height, size2.height)
+        // view3
+        XCTAssertEqual(frames[2].origin.x, fixedVStackWidth + spacing)
+        XCTAssertEqual(frames[2].origin.y, 0)
+        XCTAssertEqual(frames[2].size.width, size3.width)
+        XCTAssertEqual(frames[2].size.height, size3.height)
+    }
 }

--- a/stackableTests/StackTests.swift
+++ b/stackableTests/StackTests.swift
@@ -77,6 +77,7 @@ class StackTests: XCTestCase {
     }
 
     class MockStack: Stack {
+        var width: CGFloat?
         let thingsToStack: [Stackable]
         let spacing: CGFloat
         let layoutMargins: UIEdgeInsets


### PR DESCRIPTION
This allows us to dictate how wide a Stack should be to influence the size of the children.

eg. Below is a HStack which contains 2 VStacks. The first VStack has a width of `50` the second VStack will take up the rest of the room

If this was to layout frames with an initial width of `200` then the 2nd VStack will be `150` wide

```
+------------- HStack -------------+
| +-- V1 --+ +-------- V2 -------+ |
| |        | | +---------------+ | |
| |        | | |     Label     | | |
| |        | | +---------------+ | |
| +--------+ +-------------------+ |
+----------------------------------+
```

Only supported when nested in HStack as a VStack assumes 100% width.