### PR TITLE
Removing warnings

### DIFF
--- a/Stackable.podspec
+++ b/Stackable.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'stackable/**/*.swift'
   s.frameworks   = 'UIKit'
   s.requires_arc = true
+  s.swift_version = '4.2'
 end

--- a/stackable/HStack.swift
+++ b/stackable/HStack.swift
@@ -4,10 +4,10 @@
 import UIKit
 
 open class HStack: Stack {
-    open let thingsToStack: [Stackable]
-    open let spacing: CGFloat
-    open let layoutMargins: UIEdgeInsets
-    open let width: CGFloat?
+    public let thingsToStack: [Stackable]
+    public let spacing: CGFloat
+    public let layoutMargins: UIEdgeInsets
+    public let width: CGFloat?
     
     public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
         self.spacing = spacing

--- a/stackable/VStack.swift
+++ b/stackable/VStack.swift
@@ -4,10 +4,10 @@
 import UIKit
 
 open class VStack: Stack  {
-    open let thingsToStack: [Stackable]
-    open let spacing: CGFloat
-    open let layoutMargins: UIEdgeInsets
-    open let width: CGFloat?
+    public let thingsToStack: [Stackable]
+    public let spacing: CGFloat
+    public let layoutMargins: UIEdgeInsets
+    public let width: CGFloat?
     
     public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
         self.spacing = spacing


### PR DESCRIPTION
Removing the following warnings 

```
 -> Stackable (0.4.0)
    - WARN  | [iOS] swift: The validator used Swift 3.2 by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_version` attribute in your podspec. Note that usage of the `--swift-version` parameter or a `.swift-version` file is now deprecated.
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')
    - NOTE  | xcodebuild:  warning: Swift 3 mode has been deprecated and will be removed in a later version of Xcode. Please migrate "App" to Swift 4.2 using "Convert > To Current Swift Syntax…" in the Edit menu. (in target 'App')
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/HStack.swift:7:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/HStack.swift:8:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/HStack.swift:9:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/HStack.swift:10:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/VStack.swift:7:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/VStack.swift:8:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/VStack.swift:9:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
    - WARN  | xcodebuild:  /Users/jreyes/Documents/dev/seek-stackable/stackable/VStack.swift:10:14: warning: 'let' properties are implicitly 'final'; use 'public' instead of 'open'
```