### PR TITLE
Bump up version to 0.4.2

### DIFF
--- a/Stackable.podspec
+++ b/Stackable.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stackable'
-  s.version      = '0.4.0'
+  s.version      = '0.4.2'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = 'iOS framework for laying out nested views vertically and horizontally'
   


### PR DESCRIPTION
The `podspec` file was referencing the previous version where we had a few compilation warnings to fix

