### PR TITLE
Add a new convenience init to VStack and HStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ let attribute2 = UILabel()
 let attribute3 = UILabel()
 let logoImageView = UIImageView()
 
-let stack = VStack(spacing: 2, thingsToStack: [
-  HStack(spacing: 10, thingsToStack: [
-    VStack(spacing: 1, thingsToStack: [
+let stack = VStack(spacing: 2) {[
+  HStack(spacing: 10) {[
+    VStack(spacing: 1) {[
       attribute1,
       attribute2,
       attribute3
-    ]),
+    ]},
     logoImageView.stackSize(100, 100)
-  ]),
+  ]},
   descriptionLabel
-])
+]}
 
 let width = self.frame.size.width
 

--- a/Stackable.podspec
+++ b/Stackable.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Stackable'
-  s.version      = '0.4.2'
+  s.version      = '0.4.3'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = 'iOS framework for laying out nested views vertically and horizontally'
   

--- a/stackable/HStack.swift
+++ b/stackable/HStack.swift
@@ -16,6 +16,15 @@ open class HStack: Stack {
         self.width = width
     }
     
+    public convenience init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, width: CGFloat? = nil, thingsToStack: () -> [Stackable]) {
+        self.init(
+            spacing: spacing,
+            layoutMargins: layoutMargins,
+            thingsToStack: thingsToStack(),
+            width: width
+        )
+    }
+    
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         // TODO: add adjustments for layoutMargins (not currently needed so okay to defer)
         

--- a/stackable/VStack.swift
+++ b/stackable/VStack.swift
@@ -16,6 +16,15 @@ open class VStack: Stack  {
         self.width = width
     }
     
+    public convenience init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, width: CGFloat? = nil, thingsToStack: () -> [Stackable]) {
+        self.init(
+            spacing: spacing,
+            layoutMargins: layoutMargins,
+            thingsToStack: thingsToStack(),
+            width: width
+        )
+    }
+    
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         var origin = origin
         var width = width

--- a/stackableTests/HStackTests.swift
+++ b/stackableTests/HStackTests.swift
@@ -145,4 +145,29 @@ class HStackTests: XCTestCase {
         XCTAssertEqual(frames[2].size.width, size3.width)
         XCTAssertEqual(frames[2].size.height, size3.height)
     }
+    
+    func test_convenience_init_with_thingsToStack_closure() {
+        let layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        let spacing: CGFloat = 2
+        let view1 = UILabel()
+        let view2 = UILabel()
+        
+        let stack = HStack(
+            spacing: spacing,
+            layoutMargins: layoutMargins,
+            width: 200
+        ) {[
+            view1,
+            view2
+        ]}
+        
+        XCTAssertEqual(stack.spacing, 2)
+        XCTAssertEqual(stack.layoutMargins, layoutMargins)
+        XCTAssertEqual(stack.width, 200)
+        XCTAssertEqual(stack.thingsToStack.count, 2)
+        XCTAssertEqual(stack.thingsToStack as? [UILabel], [
+            view1,
+            view2
+        ])
+    }
 }

--- a/stackableTests/VStackTests.swift
+++ b/stackableTests/VStackTests.swift
@@ -144,4 +144,29 @@ class VStackTests: XCTestCase {
         XCTAssertEqual(frames[2].size.width, size3.width)
         XCTAssertEqual(frames[2].size.height, size3.height)
     }
+    
+    func test_convenience_init_with_thingsToStack_closure() {
+        let layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        let spacing: CGFloat = 2
+        let view1 = UILabel()
+        let view2 = UILabel()
+        
+        let stack = VStack(
+            spacing: spacing,
+            layoutMargins: layoutMargins,
+            width: 200
+        ) {[
+            view1,
+            view2
+        ]}
+        
+        XCTAssertEqual(stack.spacing, 2)
+        XCTAssertEqual(stack.layoutMargins, layoutMargins)
+        XCTAssertEqual(stack.width, 200)
+        XCTAssertEqual(stack.thingsToStack.count, 2)
+        XCTAssertEqual(stack.thingsToStack as? [UILabel], [
+            view1,
+            view2
+        ])
+    }
 }


### PR DESCRIPTION
## WHAT
Add a new convenience to make the stack declaration more concise.

## WHY
Reduce the number of lines to type, and make for easier scanning.

## HOW
Simply adding a new init with a closure.

### FROM
```
let stack = VStack(spacing: 2, thingsToStack: [
  HStack(spacing: 10, thingsToStack: [
    VStack(spacing: 1, thingsToStack: [
      attribute1,
      attribute2,
      attribute3
    ]),
    logoImageView.stackSize(100, 100)
  ]),
  descriptionLabel
])
```

### TO 

```
let stack = VStack(spacing: 2) {[
  HStack(spacing: 10) {[
    VStack(spacing: 1) {[
      attribute1,
      attribute2,
      attribute3
    ]},
    logoImageView.stackSize(100, 100)
  ]},
  descriptionLabel
]}
```
