### PR TITLE
Rename Stackable protocol to StackableProtocol

### DIFF
--- a/Sources/HStack.swift
+++ b/Sources/HStack.swift
@@ -4,15 +4,15 @@
 import UIKit
 
 open class HStack: Stack {
-    public let thingsToStack: [Stackable]
+    public let thingsToStack: [StackableProtocol]
     public let spacing: CGFloat
     public let layoutMargins: UIEdgeInsets
     public let width: CGFloat?
 
     public init(
         spacing: CGFloat = 0.0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
-        thingsToStack: [Stackable],
+        layoutMargins: UIEdgeInsets = .zero,
+        thingsToStack: [StackableProtocol],
         width: CGFloat? = nil
     ) {
         self.spacing = spacing
@@ -23,9 +23,9 @@ open class HStack: Stack {
 
     public convenience init(
         spacing: CGFloat = 0.0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
+        layoutMargins: UIEdgeInsets = .zero,
         width: CGFloat? = nil,
-        thingsToStack: () -> [Stackable]
+        thingsToStack: () -> [StackableProtocol]
     ) {
         self.init(
             spacing: spacing,
@@ -99,7 +99,7 @@ open class HStack: Stack {
 
     private func widthForNonFixedSizeStackables(
         _ width: CGFloat,
-        thingsToStack: [Stackable]
+        thingsToStack: [StackableProtocol]
     ) -> CGFloat {
         let fixedWidths =
             thingsToStack

--- a/Sources/Stack.swift
+++ b/Sources/Stack.swift
@@ -3,8 +3,8 @@
 
 import UIKit
 
-public protocol Stack: class, Stackable {
-    var thingsToStack: [Stackable] { get }
+public protocol Stack: class, StackableProtocol {
+    var thingsToStack: [StackableProtocol] { get }
     var spacing: CGFloat { get }
     var layoutMargins: UIEdgeInsets { get }
     var width: CGFloat? { get }
@@ -16,7 +16,7 @@ extension Stack {
         return self.thingsToStack.allSatisfy { $0.isHidden }
     }
 
-    func visibleThingsToStack() -> [Stackable] {
+    func visibleThingsToStack() -> [StackableProtocol] {
         return self.thingsToStack.filter({ !$0.isHidden })
     }
 

--- a/Sources/Stackable.swift
+++ b/Sources/Stackable.swift
@@ -3,7 +3,7 @@
 
 import UIKit
 
-public protocol Stackable {
+public protocol StackableProtocol {
     var isHidden: Bool { get }
     var intrinsicContentSize: CGSize { get }
 }

--- a/Sources/StackableItem.swift
+++ b/Sources/StackableItem.swift
@@ -3,6 +3,6 @@
 
 import UIKit
 
-public protocol StackableItem: Stackable {
+public protocol StackableItem: StackableProtocol {
     func heightForWidth(_ width: CGFloat) -> CGFloat
 }

--- a/Sources/VStack.swift
+++ b/Sources/VStack.swift
@@ -4,15 +4,15 @@
 import UIKit
 
 open class VStack: Stack {
-    public let thingsToStack: [Stackable]
+    public let thingsToStack: [StackableProtocol]
     public let spacing: CGFloat
     public let layoutMargins: UIEdgeInsets
     public let width: CGFloat?
 
     public init(
         spacing: CGFloat = 0.0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
-        thingsToStack: [Stackable],
+        layoutMargins: UIEdgeInsets = .zero,
+        thingsToStack: [StackableProtocol],
         width: CGFloat? = nil
     ) {
         self.spacing = spacing
@@ -23,9 +23,9 @@ open class VStack: Stack {
 
     public convenience init(
         spacing: CGFloat = 0.0,
-        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
+        layoutMargins: UIEdgeInsets = .zero,
         width: CGFloat? = nil,
-        thingsToStack: () -> [Stackable]
+        thingsToStack: () -> [StackableProtocol]
     ) {
         self.init(
             spacing: spacing,
@@ -38,7 +38,7 @@ open class VStack: Stack {
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         var origin = origin
         var width = width
-        if layoutMargins != UIEdgeInsets.zero {
+        if layoutMargins != .zero {
             origin.x += layoutMargins.left
             origin.y += layoutMargins.top
             width -= (layoutMargins.left + layoutMargins.right)

--- a/Tests/StackTests.swift
+++ b/Tests/StackTests.swift
@@ -82,14 +82,14 @@ class StackTests: XCTestCase {
 
     class MockStack: Stack {
         var width: CGFloat?
-        let thingsToStack: [Stackable]
+        let thingsToStack: [StackableProtocol]
         let spacing: CGFloat
         let layoutMargins: UIEdgeInsets
 
         init(
             spacing: CGFloat = 0.0,
             layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
-            thingsToStack: [Stackable]
+            thingsToStack: [StackableProtocol]
         ) {
             self.spacing = spacing
             self.layoutMargins = layoutMargins


### PR DESCRIPTION
## What

Rename Stackable protocol to StackableProtocol

## Why

We have found when we need to namespace Stackable components (due to a clash with another framework using components with the same name), the compiler assume's the `Stackable` namespace is referring to the protocol as opposed to the framework itself.

``` swift
import Stackable
import SwiftUI

let stack = Stackable.HStack()  // <-- there is an error here that Stackable has no object called `HStack`
```