### PR TITLE
Add `fillUsingIntrinsicContentSize` distribution support to HStack

### DIFF
--- a/Sources/HStack.swift
+++ b/Sources/HStack.swift
@@ -4,21 +4,40 @@
 import UIKit
 
 open class HStack: Stack {
+    public enum Distribution: Equatable {
+        case fillEqually
+        case fillUsingIntrinsicContentSize
+    }
     public let thingsToStack: [Stackable]
     public let spacing: CGFloat
     public let layoutMargins: UIEdgeInsets
     public let width: CGFloat?
+    public let distribution: Distribution
     
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
+    public init(
+        spacing: CGFloat = 0.0,
+        distribution: Distribution = .fillEqually,
+        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
+        thingsToStack: [Stackable],
+        width: CGFloat? = nil
+    ) {
         self.spacing = spacing
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
         self.width = width
+        self.distribution = distribution
     }
     
-    public convenience init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, width: CGFloat? = nil, thingsToStack: () -> [Stackable]) {
+    public convenience init(
+        spacing: CGFloat = 0.0,
+        distribution: Distribution = .fillEqually,
+        layoutMargins: UIEdgeInsets = UIEdgeInsets.zero,
+        width: CGFloat? = nil,
+        thingsToStack: () -> [Stackable]
+    ) {
         self.init(
             spacing: spacing,
+            distribution: distribution,
             layoutMargins: layoutMargins,
             thingsToStack: thingsToStack(),
             width: width
@@ -41,6 +60,11 @@ open class HStack: Stack {
                 stackableWidth = fixedSizeStackable.size.width
             } else if let fixedSizeStack = stackable as? Stack, let stackWidth = fixedSizeStack.width {
                 stackableWidth = stackWidth
+            } else if let item = stackable as? StackableItem, distribution == .fillUsingIntrinsicContentSize {
+                stackableWidth = min(
+                    item.intrinsicContentSize.width,
+                    (width - x)
+                )
             } else {
                 stackableWidth = nonFixedWidth
             }

--- a/Tests/HStackTests.swift
+++ b/Tests/HStackTests.swift
@@ -6,6 +6,83 @@ import Foundation
 import XCTest
 
 class HStackTests: XCTestCase {
+    func test_init_should_set_default_properties() {
+        let stack = HStack(
+            thingsToStack: []
+        )
+        
+        XCTAssertEqual(
+            stack.spacing,
+            0.0
+        )
+        XCTAssertEqual(
+            stack.distribution,
+            .fillEqually
+        )
+        XCTAssertEqual(
+            stack.layoutMargins,
+            .zero
+        )
+        XCTAssertEqual(
+            stack.thingsToStack.count,
+            0
+        )
+        XCTAssertNil(
+            stack.width
+        )
+    }
+    
+    func test_convenience_init_should_set_default_properties() {
+        let stack = HStack {
+            []
+        }
+        
+        XCTAssertEqual(
+            stack.spacing,
+            0.0
+        )
+        XCTAssertEqual(
+            stack.distribution,
+            .fillEqually
+        )
+        XCTAssertEqual(
+            stack.layoutMargins,
+            .zero
+        )
+        XCTAssertEqual(
+            stack.thingsToStack.count,
+            0
+        )
+        XCTAssertNil(
+            stack.width
+        )
+    }
+    
+    func test_convenience_init_with_thingsToStack_closure() {
+        let layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        let spacing: CGFloat = 2
+        let view1 = UILabel()
+        let view2 = UILabel()
+        
+        let stack = HStack(
+            spacing: spacing,
+            layoutMargins: layoutMargins,
+            width: 200
+        ) {[
+            view1,
+            view2
+        ]}
+        
+        XCTAssertEqual(stack.spacing, 2)
+        XCTAssertEqual(stack.layoutMargins, layoutMargins)
+        XCTAssertEqual(stack.width, 200)
+        XCTAssertEqual(stack.thingsToStack.count, 2)
+        XCTAssertEqual(stack.thingsToStack as? [UILabel], [
+            view1,
+            view2
+        ])
+    }
+    
     func test_framesForLayout_should_return_spaced_frames() {
         let spacing: CGFloat = 2
         let view1 = UIView()
@@ -146,29 +223,79 @@ class HStackTests: XCTestCase {
         XCTAssertEqual(frames[2].size.height, size3.height)
     }
     
-    func test_convenience_init_with_thingsToStack_closure() {
-        let layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-        let spacing: CGFloat = 2
-        let view1 = UILabel()
-        let view2 = UILabel()
-        
+    func test_framesForLayout_when_distribution_fillUsingIntrinsicContentSize_should_return_frames() {
+        let view1 = StackableItemView(
+            frame: .init(
+                origin: .zero,
+                size: CGSize(
+                    width: 100,
+                    height: 10
+                )
+            )
+        )
+        let view2 = StackableItemView(
+            frame: .init(
+                origin: .zero,
+                size: CGSize(
+                    width: 100,
+                    height: 20
+                )
+            )
+        )
+        let view3 = StackableItemView(
+            frame: .init(
+                origin: .zero,
+                size: CGSize(
+                    width: 200,
+                    height: 20
+                )
+            )
+        )
         let stack = HStack(
-            spacing: spacing,
-            layoutMargins: layoutMargins,
-            width: 200
-        ) {[
-            view1,
-            view2
-        ]}
+            spacing: 5,
+            distribution: .fillUsingIntrinsicContentSize
+        ) {
+            [
+                view1,
+                view2,
+                view3
+            ]
+        }
         
-        XCTAssertEqual(stack.spacing, 2)
-        XCTAssertEqual(stack.layoutMargins, layoutMargins)
-        XCTAssertEqual(stack.width, 200)
-        XCTAssertEqual(stack.thingsToStack.count, 2)
-        XCTAssertEqual(stack.thingsToStack as? [UILabel], [
-            view1,
-            view2
-        ])
+        let frames = stack.framesForLayout(300)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 100,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 105,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 100,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 210,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 90,
+                        height: 10
+                    )
+                )
+            ]
+        )
     }
     
     func test_intrinsicContentSize_should_return_correct_size() {
@@ -192,5 +319,15 @@ class HStackTests: XCTestCase {
         ])
         
         XCTAssertEqual(stack.intrinsicContentSize, .zero)
+    }
+    
+    private class StackableItemView: UIView, StackableItem {
+        override var intrinsicContentSize: CGSize {
+            frame.size
+        }
+        
+        func heightForWidth(_ width: CGFloat) -> CGFloat {
+            10
+        }
     }
 }

--- a/stackable.xcodeproj/project.pbxproj
+++ b/stackable.xcodeproj/project.pbxproj
@@ -210,7 +210,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 9D38FED21D73A077001CB50F /* Build configuration list for PBXProject "Stackable" */;
+			buildConfigurationList = 9D38FED21D73A077001CB50F /* Build configuration list for PBXProject "stackable" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -329,7 +329,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -372,7 +372,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -392,7 +392,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.seek.stackable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -413,7 +413,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.seek.stackable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -450,7 +450,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		9D38FED21D73A077001CB50F /* Build configuration list for PBXProject "Stackable" */ = {
+		9D38FED21D73A077001CB50F /* Build configuration list for PBXProject "stackable" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9D38FEEA1D73A078001CB50F /* Debug */,


### PR DESCRIPTION
## WHAT
Update `HStack` to support different distribution options instead of only `fillEqually`

## WHY
There are times where we want to show labels or a combination of views horizontally stacked and which we dont have fixed widths for.  So in these cases we want to rely on the intrinsic content size to do the fill logic for us.

## HOW
Introduce a new `fillUsingIntrinsicContentSize` distribution so that when laying out the `HStack` frames it is the views within that size themselves and use the minimum amount of space until it is all exhausted.

In the event a view doesnt fit