### PR TITLE
Fix logic error when first stackable exceeded max width

### DIFF
--- a/Sources/FlowLayoutStack.swift
+++ b/Sources/FlowLayoutStack.swift
@@ -44,7 +44,11 @@ open class FlowLayoutStack: HStack {
         var currentY = origin.y
         var currentX = origin.x
 
-        func moveToNextRow() {
+        func moveToNextRowIfRequired() {
+            guard frames.count > 0 else {
+                return
+            }
+
             currentX = 0
             currentY = frames.reduce(0) { result, rect in
                 max(
@@ -61,7 +65,7 @@ open class FlowLayoutStack: HStack {
             )
                             
             if currentX + stackableWidth > width {
-                moveToNextRow()
+                moveToNextRowIfRequired()
             }
             
             if let stack = stackable as? Stack {

--- a/Tests/FlowLayoutStackTests.swift
+++ b/Tests/FlowLayoutStackTests.swift
@@ -298,6 +298,53 @@ class FlowLayoutStackTests: XCTestCase {
         )
     }
     
+    func test_framesForLayout_when_thingsToStack_contains_a_single_stackable_that_exceeds_the_width_having_existing_origin_should_return_expected() {
+        let stack = FlowLayoutStack(
+            itemSpacing: 5,
+            lineSpacing: 10
+        ) {
+            [
+                HStack(
+                    thingsToStack: [
+                        StackableItemView(
+                            frame: .init(
+                                origin: .zero,
+                                size: CGSize(
+                                    width: 300,
+                                    height: 10
+                                )
+                            )
+                        )
+                    ]
+                )
+            ]
+        }
+
+        let frames = stack.framesForLayout(
+            100,
+            origin: .init(
+                x: 0,
+                y: 40
+            )
+        )
+
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 40
+                    ),
+                    size: .init(
+                        width: 100,
+                        height: 10
+                    )
+                ),
+            ]
+        )
+    }
+
     private class StackableItemView: UIView, StackableItem {
         override var intrinsicContentSize: CGSize {
             frame.size


### PR DESCRIPTION
There was an edge case not considered which was when the first item in the stack exceeds the width of the stack itself, dont try and move to the next row as it is the first row and should instead be restricted to the width available.