### PR TITLE
Add .fill distribution option to HStack

### DIFF
--- a/Sources/HStack.swift
+++ b/Sources/HStack.swift
@@ -4,21 +4,40 @@
 import UIKit
 
 open class HStack: Stack {
-    public let thingsToStack: [Stackable]
+    public enum Distribution: Equatable {
+        case fillEqually
+        case fill
+    }
     public let spacing: CGFloat
+    public let distribution: Distribution
     public let layoutMargins: UIEdgeInsets
+    public let thingsToStack: [Stackable]
     public let width: CGFloat?
-    
-    public init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, thingsToStack: [Stackable], width: CGFloat? = nil) {
+
+    public init(
+        spacing: CGFloat = 0.0,
+        distribution: Distribution = .fillEqually,
+        layoutMargins: UIEdgeInsets = .zero,
+        thingsToStack: [Stackable],
+        width: CGFloat? = nil
+    ) {
         self.spacing = spacing
+        self.distribution = distribution
         self.layoutMargins = layoutMargins
         self.thingsToStack = thingsToStack
         self.width = width
     }
     
-    public convenience init(spacing: CGFloat = 0.0, layoutMargins: UIEdgeInsets = UIEdgeInsets.zero, width: CGFloat? = nil, thingsToStack: () -> [Stackable]) {
+    public convenience init(
+        spacing: CGFloat = 0.0,
+        distribution: Distribution = .fillEqually,
+        layoutMargins: UIEdgeInsets = .zero,
+        width: CGFloat? = nil,
+        thingsToStack: () -> [Stackable]
+    ) {
         self.init(
             spacing: spacing,
+            distribution: distribution,
             layoutMargins: layoutMargins,
             thingsToStack: thingsToStack(),
             width: width
@@ -27,36 +46,40 @@ open class HStack: Stack {
     
     open func framesForLayout(_ width: CGFloat, origin: CGPoint) -> [CGRect] {
         // TODO: add adjustments for layoutMargins (not currently needed so okay to defer)
-        
-        let thingsToStack = self.visibleThingsToStack()
+
         var frames: [CGRect] = []
+        var currentX = origin.x
+        let currentY = origin.y
         
-        var x = origin.x
-        let y = origin.y
-        let nonFixedWidth = self.widthForNonFixedSizeStackables(width, thingsToStack: thingsToStack)
-        
-        thingsToStack.forEach { stackable in
-            let stackableWidth: CGFloat
-            if let fixedSizeStackable = stackable as? FixedSizeStackable {
-                stackableWidth = fixedSizeStackable.size.width
-            } else if let fixedSizeStack = stackable as? Stack, let stackWidth = fixedSizeStack.width {
-                stackableWidth = stackWidth
-            } else {
-                stackableWidth = nonFixedWidth
-            }
+        for stackable in visibleThingsToStack() {
+            let stackableWidth = getWidth(
+                for: stackable,
+                width: width,
+                currentX: currentX
+            )
             
             if let stack = stackable as? Stack {
-                let innerFrames = stack.framesForLayout(stackableWidth, origin: CGPoint(x: x, y: origin.y))
-                frames.append(contentsOf: innerFrames)
-                x += stackableWidth
+                frames.append(
+                    contentsOf: stack.framesForLayout(
+                        stackableWidth,
+                        origin: CGPoint(
+                            x: currentX,
+                            y: currentY
+                        )
+                    )
+                )
             } else if let item = stackable as? StackableItem {
-                let stackableHeight = item.heightForWidth(stackableWidth)
-                let frame = CGRect(x: x, y: y, width: stackableWidth, height: stackableHeight)
-                frames.append(frame)
-                x += stackableWidth
+                frames.append(
+                    .init(
+                        x: currentX,
+                        y: currentY,
+                        width: stackableWidth,
+                        height: item.heightForWidth(stackableWidth)
+                    )
+                )
             }
             
-            x += self.spacing
+            currentX += stackableWidth + spacing
         }
         
         return frames
@@ -82,6 +105,37 @@ open class HStack: Stack {
     
     // MARK: helpers
     
+    private func getWidth(
+        for stackable: Stackable,
+        width: CGFloat,
+        currentX: Double
+    ) -> CGFloat {
+        let thingsToStack = visibleThingsToStack()
+        
+        if let fixedSizeStackable = stackable as? FixedSizeStackable {
+            return fixedSizeStackable.size.width
+        } else if let stack = stackable as? Stack, let fixedSizeStackWidth = stack.width {
+            return fixedSizeStackWidth
+        } else if stackable as? Stack !== nil, distribution == .fill {
+            return width
+        } 
+        else if let item = stackable as? StackableItem, distribution == .fill {
+            let itemWidth = item.intrinsicContentSize.width
+            let widthBalance = width - currentX
+
+            if widthBalance > 0 {
+                return itemWidth <= widthBalance ? itemWidth : widthBalance
+            } else {
+                return 0
+            }
+        } else {
+            return widthForNonFixedSizeStackables(
+                width,
+                thingsToStack: thingsToStack
+            )
+        }
+    }
+
     private  func widthForNonFixedSizeStackables(_ width: CGFloat, thingsToStack: [Stackable]) -> CGFloat {
         let fixedWidths = thingsToStack
             .filter {
@@ -100,6 +154,6 @@ open class HStack: Stack {
         let totalFixedWidth = fixedWidths.reduce(0.0, +)
         let totalNonFixedWidth = width - totalFixedWidth - (((CGFloat(thingsToStack.count) - 1) * self.spacing))
         let numberOfStackablesWithNonFixedWidth = thingsToStack.count - fixedWidths.count
-        return  floor(totalNonFixedWidth / CGFloat(numberOfStackablesWithNonFixedWidth))
+        return floor(totalNonFixedWidth / CGFloat(numberOfStackablesWithNonFixedWidth))
     }
 }

--- a/Sources/HStack.swift
+++ b/Sources/HStack.swift
@@ -172,7 +172,10 @@ open class HStack: Stack {
             if let fixedSizeStackWidth = stack.width {
                 return fixedSizeStackWidth
             } else {
-                return width - currentX
+                return min(
+                    width - currentX,
+                    stack.intrinsicContentSize.width
+                )
             }
         }
         else if let item = stackable as? StackableItem {

--- a/Tests/HStackTests.swift
+++ b/Tests/HStackTests.swift
@@ -1076,27 +1076,138 @@ final class HStackTests: XCTestCase {
             ]
         )
     }
-    
-    func test_intrinsicContentSize_should_return_correct_size() {
-        let stack = HStack(spacing: 5, thingsToStack: [
-            UIView().fixed(width: 100, height: 100),
-            UIView().fixed(width: 200, height: 50)
-        ])
-        
-        XCTAssertEqual(stack.intrinsicContentSize, CGSize(width: 305, height: 100))
+
+    func test_intrinsicContentSize_when_distribution_is_fillEqually_and_thingsToStack_empty_should_return_zero() {
+        let stack = HStack(
+            spacing: 5,
+            thingsToStack: []
+        )
+
+        XCTAssertEqual(stack.intrinsicContentSize, .zero)
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fill_and_thingsToStack_empty_should_return_zero() {
+        let stack = HStack(
+            spacing: 5,
+            distribution: .fill,
+            thingsToStack: []
+        )
+
+        XCTAssertEqual(stack.intrinsicContentSize, .zero)
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fillEqually_and_width_is_set_should_return_expected_size() {
+        let stack = HStack(
+            spacing: 5,
+            thingsToStack: [
+                UIView().fixed(width: 100, height: 100),
+                UIView().fixed(width: 200, height: 50)
+            ],
+            width: 300
+        )
+
+        XCTAssertEqual(
+            stack.intrinsicContentSize,
+            CGSize(width: 305, height: 100)
+        )
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fill_and_width_is_set_should_return_expected_size() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+
+        let stack = HStack(
+            spacing: 5,
+            distribution: .fill,
+            thingsToStack: [
+                label1,
+                label2,
+                label3
+            ],
+            width: 300
+        )
+
+        XCTAssertEqual(
+            stack.intrinsicContentSize,
+            CGSize(width: 248.5, height: 20.5)
+        )
     }
     
-    func test_intrinsicContentSize_should_return_zero_when_items_are_hidden() {
+    func test_intrinsicContentSize_when_distribution_is_fillEqually_and_width_is_not_set_should_return_expected_size() {
+        let stack = HStack(
+            spacing: 5,
+            thingsToStack: [
+                UIView().fixed(width: 100, height: 100),
+                UIView().fixed(width: 200, height: 50)
+            ]
+        )
+
+        XCTAssertEqual(
+            stack.intrinsicContentSize,
+            CGSize(width: 305, height: 100)
+        )
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fill_and_width_is_not_set_should_return_expected_size() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+
+        let stack = HStack(
+            spacing: 5,
+            distribution: .fill,
+            thingsToStack: [
+                label1,
+                label2,
+                label3
+            ]
+        )
+
+        XCTAssertEqual(
+            stack.intrinsicContentSize,
+            CGSize(width: 248.5, height: 20.5)
+        )
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fillEqually_and_items_are_hidden_should_return_zero() {
         let view1 = UIView()
         view1.isHidden = true
         let view2 = UIView()
         view2.isHidden = true
-        
-        let stack = HStack(spacing: 5, thingsToStack: [
-            view1.fixed(width: 100, height: 100),
-            view2.fixed(width: 200, height: 50)
-        ])
-        
+
+        let stack = HStack(
+            spacing: 5,
+            thingsToStack: [
+                view1.fixed(width: 100, height: 100),
+                view2.fixed(width: 200, height: 50)
+            ]
+        )
+
+        XCTAssertEqual(stack.intrinsicContentSize, .zero)
+    }
+
+    func test_intrinsicContentSize_when_distribution_is_fill_and_items_are_hidden_should_return_zero() {
+        let view1 = UIView()
+        view1.isHidden = true
+        let view2 = UIView()
+        view2.isHidden = true
+
+        let stack = HStack(
+            spacing: 5,
+            distribution: .fill,
+            thingsToStack: [
+                view1.fixed(width: 100, height: 100),
+                view2.fixed(width: 200, height: 50)
+            ]
+        )
+
         XCTAssertEqual(stack.intrinsicContentSize, .zero)
     }
 }

--- a/Tests/HStackTests.swift
+++ b/Tests/HStackTests.swift
@@ -119,7 +119,58 @@ final class HStackTests: XCTestCase {
         )
     }
     
-    func test_framesForLayout_should_return_expected_frames() {
+    func test_framesForLayout_should_return_frames_with_margins() {
+        let stack = HStack(
+            spacing: 2,
+            layoutMargins: .init(
+                top: 10,
+                left: 8,
+                bottom: 10,
+                right: 8
+            ),
+            thingsToStack: [
+                UIView().fixed(
+                    size: CGSize(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                UIView().fixed(
+                    size: CGSize(
+                        width: 55,
+                        height: 11
+                    )
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0 // TODO: HStack is currently not respecting margins
+                    ),
+                    size: .init(
+                        width: 55,
+                        height: 11
+                    )
+                )
+            ]
+        )
+    }
+
+    func test_framesForLayout_when_distribution_is_fillEqually_and_all_items_are_fixed_size_should_return_expected_frames() {
         let stack = HStack(
             spacing: 2,
             thingsToStack: [
@@ -181,26 +232,27 @@ final class HStackTests: XCTestCase {
         )
     }
 
-    func test_framesForLayout_should_return_frames_with_margins() {
+    func test_framesForLayout_when_distribution_is_fillEqually_and_items_are_mixed_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Some text"
+        let label2 = UILabel()
+        label2.text = "Some longer text"
+
         let stack = HStack(
             spacing: 2,
-            layoutMargins: .init(
-                top: 10,
-                left: 8,
-                bottom: 10,
-                right: 8
-            ),
             thingsToStack: [
-                UIView().fixed(
-                    size: CGSize(
-                        width: 50,
-                        height: 10
-                    )
-                ),
+                label1,
                 UIView().fixed(
                     size: CGSize(
                         width: 55,
                         height: 11
+                    )
+                ),
+                label2,
+                UIView().fixed(
+                    size: CGSize(
+                        width: 60,
+                        height: 12
                     )
                 )
             ]
@@ -214,25 +266,45 @@ final class HStackTests: XCTestCase {
                 .init(
                     origin: .zero,
                     size: .init(
-                        width: 50,
-                        height: 10
+                        width: 39,
+                        height: 20.5
                     )
                 ),
                 .init(
                     origin: .init(
-                        x: 52,
-                        y: 0 // TODO: HStack is currently not respecting margins
+                        x: 41,
+                        y: 0
                     ),
                     size: .init(
                         width: 55,
                         height: 11
                     )
+                ),
+                .init(
+                    origin: .init(
+                        x: 98,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 39,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 139,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
                 )
             ]
         )
     }
-
-    func test_framesForLayout_should_return_frames_for_nested_vstack() {
+    
+    func test_framesForLayout_when_distribution_is_fillEqually_and_having_vstack_as_children_should_return_expected_frames() {
         let stack = HStack(
             spacing: 2,
             thingsToStack: [
@@ -298,19 +370,91 @@ final class HStackTests: XCTestCase {
         )
     }
     
-    func test_framesForLayout_should_return_frames_for_nested_vstack_with_fixed_width() {
+    func test_framesForLayout_when_distribution_is_fillEqually_and_having_children_with_distribution_fillEqually_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+        
+        let stack = HStack(
+            spacing: 4,
+            thingsToStack: [
+                label1,
+                HStack(
+                    spacing: 8,
+                    thingsToStack: [
+                        label2,
+                        UIView().fixed(
+                            size: .init(
+                                width: 20,
+                                height: 16
+                            )
+                        ),
+                        label3
+                    ]
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 98,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 102,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 31,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 141,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 20,
+                        height: 16
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 169,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 31,
+                        height: 20.5
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fillEqually_should_return_frames_for_nested_vstack_with_fixed_width() {
+        let label = UILabel()
+        label.text = "Some longer longer text"
+        
         let stack = HStack(
             spacing: 2,
             thingsToStack: [
                 VStack(
                     spacing: 1,
                     thingsToStack: [
-                        UIView().fixed(
-                            size: .init(
-                                width: 100,
-                                height: 10
-                            )
-                        ),
+                        label,
                         UIView().fixed(
                             size: .init(
                                 width: 100,
@@ -338,13 +482,13 @@ final class HStackTests: XCTestCase {
                     origin: .zero,
                     size: .init(
                         width: 50,
-                        height: 10
+                        height: 20.5
                     )
                 ),
                 .init(
                     origin: .init(
                         x: 0,
-                        y: 11
+                        y: 21.5
                     ),
                     size: .init(
                         width: 50,
@@ -365,7 +509,85 @@ final class HStackTests: XCTestCase {
         )
     }
     
-    func test_framesForLayout_when_distribution_is_fill_should_return_expected_frames() {
+    func test_framesForLayout_when_distribution_is_fill_and_all_items_are_fixed_size_should_return_expected_frames_with_dropped_last_item_that_exceed_hstack_width() {
+        let stack = HStack(
+            spacing: 4,
+            distribution: .fill,
+            thingsToStack: [
+                UIView().fixed(
+                    size: .init(
+                        width: 20,
+                        height: 14
+                    )
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 100,
+                        height: 14
+                    )
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 145,
+                        height: 14
+                    )
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 120,
+                        height: 14
+                    )
+                ),
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 20,
+                        height: 14
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 24,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 100,
+                        height: 14
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 128,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 72,
+                        height: 14
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 204,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 14
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_and_items_are_mixed_should_return_expected_frames_with_dropped_last_item_that_exceed_hstack_width() {
         let label1 = UILabel()
         label1.text = "Some text"
         let label2 = UILabel()
@@ -429,6 +651,100 @@ final class HStackTests: XCTestCase {
                     size: .init(
                         width: 0,
                         height: 20.5
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_and_having_vstack_as_children_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Some text"
+        let label2 = UILabel()
+        label2.text = "Some longer text"
+
+        let stack = HStack(
+            spacing: 2,
+            distribution: .fill,
+            thingsToStack: [
+                VStack(
+                    spacing: 1,
+                    thingsToStack: [
+                        UIView().fixed(
+                            size: .init(
+                                width: 50,
+                                height: 10
+                            )
+                        ),
+                        UIView().fixed(
+                            size: .init(
+                                width: 55,
+                                height: 11
+                            )
+                        )
+                    ]
+                ),
+                label1,
+                label2,
+                UIView().fixed(
+                    size: .init(
+                        width: 100,
+                        height: 12
+                    )
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 11
+                    ),
+                    size: .init(
+                        width: 55,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 57,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 77,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 136,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 64,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 202,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 12
                     )
                 )
             ]
@@ -521,6 +837,74 @@ final class HStackTests: XCTestCase {
                     size: .init(
                         width: 0,
                         height: 14
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_should_return_frames_for_nested_vstack_with_fixed_width() {
+        let stack = HStack(
+            spacing: 2,
+            distribution: .fill,
+            thingsToStack: [
+                VStack(
+                    spacing: 1,
+                    thingsToStack: [
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 10
+                            )
+                        ),
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 11
+                            )
+                        )
+                    ],
+                    width: 50
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 11
+                    ),
+                    size: .init(
+                        width: 50,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
                     )
                 )
             ]
@@ -687,74 +1071,6 @@ final class HStackTests: XCTestCase {
                     size: .init(
                         width: 30,
                         height: 14
-                    )
-                )
-            ]
-        )
-    }
-    
-    func test_framesForLayout_when_distribution_is_fill_should_return_frames_for_nested_vstack_with_fixed_width() {
-        let stack = HStack(
-            spacing: 2,
-            distribution: .fill,
-            thingsToStack: [
-                VStack(
-                    spacing: 1,
-                    thingsToStack: [
-                        UIView().fixed(
-                            size: .init(
-                                width: 100,
-                                height: 10
-                            )
-                        ),
-                        UIView().fixed(
-                            size: .init(
-                                width: 100,
-                                height: 11
-                            )
-                        )
-                    ],
-                    width: 50
-                ),
-                UIView().fixed(
-                    size: .init(
-                        width: 60,
-                        height: 12
-                    )
-                )
-            ]
-        )
-        
-        let frames = stack.framesForLayout(200)
-        
-        XCTAssertEqual(
-            frames,
-            [
-                .init(
-                    origin: .zero,
-                    size: .init(
-                        width: 50,
-                        height: 10
-                    )
-                ),
-                .init(
-                    origin: .init(
-                        x: 0,
-                        y: 11
-                    ),
-                    size: .init(
-                        width: 50,
-                        height: 11
-                    )
-                ),
-                .init(
-                    origin: .init(
-                        x: 52,
-                        y: 0
-                    ),
-                    size: .init(
-                        width: 60,
-                        height: 12
                     )
                 )
             ]

--- a/Tests/HStackTests.swift
+++ b/Tests/HStackTests.swift
@@ -1,174 +1,764 @@
 //  Copyright © 2016 SEEK Limited. All rights reserved.
 //
 
-import Foundation
 import XCTest
+
 @testable import Stackable
 
-class HStackTests: XCTestCase {
-    func test_framesForLayout_should_return_spaced_frames() {
-        let spacing: CGFloat = 2
-        let view1 = UIView()
-        let size1 = CGSize(width: 50, height: 10)
-        let view2 = UIView()
-        let size2 = CGSize(width: 55, height: 11)
-        let view3 = UIView()
-        let size3 = CGSize(width: 60, height: 12)
+final class HStackTests: XCTestCase {
+    func test_init_should_set_default_properties() {
+        let stack = HStack(
+            thingsToStack: []
+        )
         
-        let stack = HStack(spacing: spacing, thingsToStack: [
-            view1.fixed(size: size1),
-            view2.fixed(size: size2),
-            view3.fixed(size: size3)
-        ])
+        XCTAssertEqual(
+            stack.spacing,
+            0.0
+        )
+        XCTAssertEqual(
+            stack.distribution,
+            .fillEqually
+        )
+        XCTAssertEqual(
+            stack.layoutMargins,
+            .zero
+        )
+        XCTAssertEqual(
+            stack.thingsToStack.count,
+            0
+        )
+        XCTAssertNil(
+            stack.width
+        )
+    }
+    
+    func test_init_should_set_properties() {
+        let stack = HStack(
+            spacing: 8,
+            distribution: .fill,
+            layoutMargins: .init(
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10
+            ),
+            thingsToStack: [
+                UILabel()
+            ],
+            width: 100
+        )
+        
+        XCTAssertEqual(
+            stack.spacing,
+            8
+        )
+        XCTAssertEqual(
+            stack.distribution,
+            .fill
+        )
+        XCTAssertEqual(
+            stack.layoutMargins,
+            .init(
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10
+            )
+        )
+        XCTAssertEqual(
+            stack.width,
+            100
+        )
+        XCTAssertEqual(
+            stack.thingsToStack.count,
+            1
+        )
+    }
+    
+    func test_convenience_init_should_set_properties() {
+        let stack = HStack(
+            spacing: 8,
+            distribution: .fill,
+            layoutMargins: .init(
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10
+            ),
+            width: 100
+        ) {
+            [
+                UILabel()
+            ]
+        }
+        
+        XCTAssertEqual(
+            stack.spacing,
+            8
+        )
+        XCTAssertEqual(
+            stack.distribution,
+            .fill
+        )
+        XCTAssertEqual(
+            stack.layoutMargins,
+            .init(
+                top: 10,
+                left: 10,
+                bottom: 10,
+                right: 10
+            )
+        )
+        XCTAssertEqual(
+            stack.width,
+            100
+        )
+        XCTAssertEqual(
+            stack.thingsToStack.count,
+            1
+        )
+    }
+    
+    func test_framesForLayout_should_return_expected_frames() {
+        let stack = HStack(
+            spacing: 2,
+            thingsToStack: [
+                UIView().fixed(
+                    size: CGSize(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                UIView().fixed(
+                    size: CGSize(
+                        width: 55,
+                        height: 11
+                    )
+                ),
+                UIView().fixed(
+                    size: CGSize(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
         
         let frames = stack.framesForLayout(200)
-        XCTAssertEqual(frames.count, 3)
-        // view1
-        XCTAssertEqual(frames[0].origin.x, 0)
-        XCTAssertEqual(frames[0].origin.y, 0)
-        XCTAssertEqual(frames[0].size.width, size1.width)
-        XCTAssertEqual(frames[0].size.height, size1.height)
-        // view2
-        XCTAssertEqual(frames[1].origin.x, size1.width + spacing)
-        XCTAssertEqual(frames[1].origin.y, 0)
-        XCTAssertEqual(frames[1].size.width, size2.width)
-        XCTAssertEqual(frames[1].size.height, size2.height)
-        // view3
-        XCTAssertEqual(frames[2].origin.x, size1.width + spacing + size2.width + spacing)
-        XCTAssertEqual(frames[2].origin.y, 0)
-        XCTAssertEqual(frames[2].size.width, size3.width)
-        XCTAssertEqual(frames[2].size.height, size3.height)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 55,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 109,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+                
+            ]
+        )
     }
 
     func test_framesForLayout_should_return_frames_with_margins() {
-        let topMargin: CGFloat = 10
-        let leftMargin: CGFloat = 8
-        let bottomMargin: CGFloat = 10
-        let rightMargin: CGFloat = 8
-
-        let spacing: CGFloat = 2
-        let view1 = UIView()
-        let size1 = CGSize(width: 50, height: 10)
-        let view2 = UIView()
-        let size2 = CGSize(width: 55, height: 11)
-        
-        let stack = HStack(spacing: spacing, layoutMargins: UIEdgeInsets(top: topMargin, left: leftMargin, bottom: bottomMargin, right: rightMargin), thingsToStack: [
-            view1.fixed(size: size1),
-            view2.fixed(size: size2)
-            ])
+        let stack = HStack(
+            spacing: 2,
+            layoutMargins: .init(
+                top: 10,
+                left: 8,
+                bottom: 10,
+                right: 8
+            ),
+            thingsToStack: [
+                UIView().fixed(
+                    size: CGSize(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                UIView().fixed(
+                    size: CGSize(
+                        width: 55,
+                        height: 11
+                    )
+                )
+            ]
+        )
         
         let frames = stack.framesForLayout(200)
-        XCTAssertEqual(frames.count, 2)
-        // view1
-        XCTAssertEqual(frames[0].origin.x, 0)
-        XCTAssertEqual(frames[0].origin.y, 0) // TODO: HStack is currently not respecting margins
-        XCTAssertEqual(frames[0].size.width, size1.width)
-        XCTAssertEqual(frames[0].size.height, size1.height)
-        // view2
-        XCTAssertEqual(frames[1].origin.x, size1.width + spacing)
-        XCTAssertEqual(frames[1].origin.y, 0)
-        XCTAssertEqual(frames[1].size.width, size2.width)
-        XCTAssertEqual(frames[1].size.height, size2.height)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0 // TODO: HStack is currently not respecting margins
+                    ),
+                    size: .init(
+                        width: 55,
+                        height: 11
+                    )
+                )
+            ]
+        )
     }
 
     func test_framesForLayout_should_return_frames_for_nested_vstack() {
-        let spacing: CGFloat = 2
-        let spacing2: CGFloat = 1
-        let view1 = UIView()
-        let size1 = CGSize(width: 50, height: 10)
-        let view2 = UIView()
-        let size2 = CGSize(width: 55, height: 11)
-        let view3 = UIView()
-        let size3 = CGSize(width: 60, height: 12)
-        
-        let stack = HStack(spacing: spacing, thingsToStack: [
-            VStack(spacing: spacing2, thingsToStack: [
-                view1.fixed(size: size1),
-                view2.fixed(size: size2)
-                ]),
-            view3.fixed(size: size3)
-        ])
+        let stack = HStack(
+            spacing: 2,
+            thingsToStack: [
+                VStack(
+                    spacing: 1,
+                    thingsToStack: [
+                        UIView().fixed(
+                            size: .init(
+                                width: 50,
+                                height: 10
+                            )
+                        ),
+                        UIView().fixed(
+                            size: .init(
+                                width: 55,
+                                height: 11
+                            )
+                        )
+                    ]
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
         
         let frames = stack.framesForLayout(200)
-        XCTAssertEqual(frames.count, 3)
-        // view1
-        XCTAssertEqual(frames[0].origin.x, 0)
-        XCTAssertEqual(frames[0].origin.y, 0)
-        XCTAssertEqual(frames[0].size.width, 50)
-        XCTAssertEqual(frames[0].size.height, size1.height)
-        // view2
-        XCTAssertEqual(frames[1].origin.x, 0)
-        XCTAssertEqual(frames[1].origin.y, size1.height + spacing2)
-        XCTAssertEqual(frames[1].size.width, 55)
-        XCTAssertEqual(frames[1].size.height, size2.height)
-        // view3
-        XCTAssertEqual(frames[2].origin.x, 200 - size3.width)
-        XCTAssertEqual(frames[2].origin.y, 0)
-        XCTAssertEqual(frames[2].size.width, size3.width)
-        XCTAssertEqual(frames[2].size.height, size3.height)
+
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 11
+                    ),
+                    size: .init(
+                        width: 55,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 140,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
     }
     
     func test_framesForLayout_should_return_frames_for_nested_vstack_with_fixed_width() {
-        let spacing: CGFloat = 2
-        let spacing2: CGFloat = 1
-        let view1 = UIView()
-        let size1 = CGSize(width: 100, height: 10)
-        let view2 = UIView()
-        let size2 = CGSize(width: 100, height: 11)
-        let view3 = UIView()
-        let size3 = CGSize(width: 60, height: 12)
-        let fixedVStackWidth: CGFloat = 50
-        
-        let stack = HStack(spacing: spacing, thingsToStack: [
-            VStack(spacing: spacing2, thingsToStack: [
-                view1.fixed(size: size1),
-                view2.fixed(size: size2)
-            ], width: fixedVStackWidth),
-            view3.fixed(size: size3)
-        ])
+        let stack = HStack(
+            spacing: 2,
+            thingsToStack: [
+                VStack(
+                    spacing: 1,
+                    thingsToStack: [
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 10
+                            )
+                        ),
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 11
+                            )
+                        )
+                    ],
+                    width: 50
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
         
         let frames = stack.framesForLayout(200)
-        XCTAssertEqual(frames.count, 3)
-        // view1
-        XCTAssertEqual(frames[0].origin.x, 0)
-        XCTAssertEqual(frames[0].origin.y, 0)
-        XCTAssertEqual(frames[0].size.width, fixedVStackWidth)
-        XCTAssertEqual(frames[0].size.height, size1.height)
-        // view2
-        XCTAssertEqual(frames[1].origin.x, 0)
-        XCTAssertEqual(frames[1].origin.y, size1.height + spacing2)
-        XCTAssertEqual(frames[1].size.width, fixedVStackWidth)
-        XCTAssertEqual(frames[1].size.height, size2.height)
-        // view3
-        XCTAssertEqual(frames[2].origin.x, fixedVStackWidth + spacing)
-        XCTAssertEqual(frames[2].origin.y, 0)
-        XCTAssertEqual(frames[2].size.width, size3.width)
-        XCTAssertEqual(frames[2].size.height, size3.height)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 11
+                    ),
+                    size: .init(
+                        width: 50,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
     }
     
-    func test_convenience_init_with_thingsToStack_closure() {
-        let layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-        let spacing: CGFloat = 2
-        let view1 = UILabel()
-        let view2 = UILabel()
+    func test_framesForLayout_when_distribution_is_fill_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Some text"
+        let label2 = UILabel()
+        label2.text = "Some longer text"
+        let label3 = UILabel()
+        label3.text = "Some longer longer text"
         
         let stack = HStack(
-            spacing: spacing,
-            layoutMargins: layoutMargins,
-            width: 200
-        ) {[
-            view1,
-            view2
-        ]}
+            spacing: 4,
+            distribution: .fill,
+            thingsToStack: [
+                label1,
+                UIView().fixed(
+                    size: .init(
+                        width: 100,
+                        height: 14
+                    )
+                ),
+                label2,
+                label3
+            ]
+        )
         
-        XCTAssertEqual(stack.spacing, 2)
-        XCTAssertEqual(stack.layoutMargins, layoutMargins)
-        XCTAssertEqual(stack.width, 200)
-        XCTAssertEqual(stack.thingsToStack.count, 2)
-        XCTAssertEqual(stack.thingsToStack as? [UILabel], [
-            view1,
-            view2
-        ])
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 77,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 81,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 100,
+                        height: 14
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 185,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 15,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 204,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 20.5
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_and_having_children_with_distribution_fill_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+        
+        let stack = HStack(
+            spacing: 4,
+            distribution: .fill,
+            thingsToStack: [
+                label1,
+                HStack(
+                    spacing: 8,
+                    distribution: .fill,
+                    thingsToStack: [
+                        label2,
+                        UIView().fixed(
+                            size: .init(
+                                width: 15,
+                                height: 16
+                            )
+                        ),
+                        label3,
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 14
+                            )
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 32,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 36,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 77,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 121,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 15,
+                        height: 16
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 144,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 56,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 208,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 14
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fillEqually_and_having_children_with_distribution_fill_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+        
+        let stack = HStack(
+            spacing: 4,
+            thingsToStack: [
+                label1,
+                HStack(
+                    spacing: 8,
+                    distribution: .fill,
+                    thingsToStack: [
+                        label2,
+                        UIView().fixed(
+                            size: .init(
+                                width: 15,
+                                height: 16
+                            )
+                        ),
+                        label3,
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 14
+                            )
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 98,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 102,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 77,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 187,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 13,
+                        height: 16
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 208,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 216,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 0,
+                        height: 14
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_and_having_children_with_distribution_fillEqually_should_return_expected_frames() {
+        let label1 = UILabel()
+        label1.text = "Text"
+        let label2 = UILabel()
+        label2.text = "Some text"
+        let label3 = UILabel()
+        label3.text = "Some longer text"
+        
+        let stack = HStack(
+            spacing: 4,
+            distribution: .fill,
+            thingsToStack: [
+                label1,
+                HStack(
+                    spacing: 8,
+                    thingsToStack: [
+                        label2,
+                        label3,
+                        UIView().fixed(
+                            size: .init(
+                                width: 30,
+                                height: 14
+                            )
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 32,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 36,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 59,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 103,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 59,
+                        height: 20.5
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 170,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 30,
+                        height: 14
+                    )
+                )
+            ]
+        )
+    }
+    
+    func test_framesForLayout_when_distribution_is_fill_should_return_frames_for_nested_vstack_with_fixed_width() {
+        let stack = HStack(
+            spacing: 2,
+            distribution: .fill,
+            thingsToStack: [
+                VStack(
+                    spacing: 1,
+                    thingsToStack: [
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 10
+                            )
+                        ),
+                        UIView().fixed(
+                            size: .init(
+                                width: 100,
+                                height: 11
+                            )
+                        )
+                    ],
+                    width: 50
+                ),
+                UIView().fixed(
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
+        
+        let frames = stack.framesForLayout(200)
+        
+        XCTAssertEqual(
+            frames,
+            [
+                .init(
+                    origin: .zero,
+                    size: .init(
+                        width: 50,
+                        height: 10
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 0,
+                        y: 11
+                    ),
+                    size: .init(
+                        width: 50,
+                        height: 11
+                    )
+                ),
+                .init(
+                    origin: .init(
+                        x: 52,
+                        y: 0
+                    ),
+                    size: .init(
+                        width: 60,
+                        height: 12
+                    )
+                )
+            ]
+        )
     }
     
     func test_intrinsicContentSize_should_return_correct_size() {


### PR DESCRIPTION
Adding a new distribution option called `fill` in the `HStack` to enable filling overall frames width with the item intrinsicContentSize width without the need for us to give a `fixed` width each time for a `Stack/StackableItem`.

| existing `.fillEqually` | new `.fill` |
| --- | --- |
|  <img width="369" alt="image" src="https://github.com/seek-oss/seek-stackable/assets/56019484/33dc328c-360b-4224-93c0-581c95e9b13f"> |  <img width="368" alt="image" src="https://github.com/seek-oss/seek-stackable/assets/56019484/63c0c30d-c364-4b2a-b6ae-1adb982af652"> |

For example the above can be recreated with the following example.

```   
let stack = HStack(
    spacing: Spacing.xxsmall.value,
    distribution: .fill,
    thingsToStack: [
         icon,
         label,
         label2
     ]
)
```
Before `.fill` option being introduced the above code will results in similar to the first picture in the table above. Now the `.fill` distribution option takes the intrinsicContentSize width of an item and set that as the width it need to satisfy on the frames we lay out.

## Note
For `.fill` distribution option, when an item cant fit in the `HStack` the item will be dropped off from the view.

Example :-
```
let stack = HStack(
    spacing: Spacing.xxsmall.value,
    distribution: .fill,
    thingsToStack: [
        Icon(),
        Label(text: "Be among the first to apply"),
        Label(text: "Label 2 something longer longer longer longer"),
        Label(text: "Label 3 something longer longer longer longer longer longer"),
     ]
)
```
This will yield something like this with `Label 3...` being drop off from the view because it cant fit.

<img width="364" alt="image" src="https://github.com/seek-oss/seek-stackable/assets/56019484/48d903bd-ebb9-4f78-81c6-ccae45d31e48">

This behaviour is similar to what we get when we use the native `UIStackView`. 

Example:

```
let view = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 400))

let hstack1 = hStack()

view.addSubview(hstack1)

hstack1.addArrangedSubview(
    label("title 1")
)
hstack1.addArrangedSubview(
    label("Super long long long long long long title lets see")
)
hstack1.addArrangedSubview(
    label("title 3")
)
```

The native `UIStackView` will yield something like this with `title 3` being dropped out because it cant fit.
<img width="444" alt="image" src="https://github.com/seek-oss/seek-stackable/assets/56019484/5ace9d41-1cbf-459d-85a5-4dfc900c73ec">


